### PR TITLE
Fix TVM Performance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git@github.com:mlcommons/inference.git
 [submodule "dependencies/tvm"]
 	path = dependencies/tvm
-	url = https://github.com/apache/tvm
+	url = git@github.com:NathanTP/tvm.git 

--- a/inference/benchmark/localBench.py
+++ b/inference/benchmark/localBench.py
@@ -76,11 +76,11 @@ def runNative(model, constants, inputs, preOut):
 
 
 def _runOne(model, constants, inputs, stats=None, kaasCtx=None, kaasHandle=None, constKeys=None):
-    with util.timer("pre", stats):
+    with infbench.timer("pre", stats):
         preInp = util.packInputs(model.preMap, const=constants, inp=inputs)
         preOut = model.pre(preInp)
 
-    with util.timer("run", stats):
+    with infbench.timer("run", stats):
         if kaasCtx is not None:
             runOut = runKaas(model, kaasCtx, kaasHandle, constKeys, inputs, preOut)
         else:
@@ -89,7 +89,7 @@ def _runOne(model, constants, inputs, stats=None, kaasCtx=None, kaasHandle=None,
     if model.noPost:
         postOut = runOut
     else:
-        with util.timer("post", stats):
+        with infbench.timer("post", stats):
             postInp = util.packInputs(model.postMap, const=constants, inp=inputs, pre=preOut, run=runOut)
             postOut = model.post(postInp)
 
@@ -98,7 +98,7 @@ def _runOne(model, constants, inputs, stats=None, kaasCtx=None, kaasHandle=None,
 
 def nShot(modelSpec, n, benchConfig, reportPath="results.json"):
     loader, models = _getHandlers(modelSpec)
-    stats = util.profCollection()
+    stats = infbench.profCollection()
 
     loader.preLoad(list(range(min(n, loader.ndata))))
     model = models[0]
@@ -132,7 +132,7 @@ def nShot(modelSpec, n, benchConfig, reportPath="results.json"):
         inputs = loader.get(idx)
 
         cuda.start_profiler()
-        with util.timer("t_e2e", stats):
+        with infbench.timer("t_e2e", stats):
             result = _runOne(model, constants, inputs, stats=stats, kaasCtx=kaasCtx, kaasHandle=kaasHandle, constKeys=constKeys)
         cuda.stop_profiler()
 


### PR DESCRIPTION
Switch TVM submodule to our fork. This fixes the performance discrepancy between TVM and KaaS.