### PR TITLE
Unique Ephemeral Buffer Namespaces

### DIFF
--- a/inference/benchmark/client.py
+++ b/inference/benchmark/client.py
@@ -145,7 +145,7 @@ def nShot(modelSpec, n, benchConfig):
     # Send all requests
     print("Sending Requests:")
     results = _nShotAsync(inpIds[:n], loader, serverSocket,
-                         stats=stats, cacheInputs=modelSpec.cacheInputs)
+                          stats=stats, cacheInputs=modelSpec.cacheInputs)
     print("Test complete")
 
     if loader.checkAvailable:

--- a/inference/benchmark/experiment.py
+++ b/inference/benchmark/experiment.py
@@ -103,19 +103,6 @@ def runTest(test, modelNames, modelType, prefix, resultsDir, nCpy=1, scale=1.0, 
 
                 return False
 
-    if test == 'nshot':
-        modelThroughputs = {name: 0 for name in modelNames}
-        for i in range(nCpy):
-            for j, modelName in enumerate(modelNames):
-                instanceName = f"{prefix}_{modelName}_{j}_{i}"
-
-                with open(resultsDir / (instanceName + "_results.json"), 'r') as f:
-                    instanceMetrics = json.load(f)
-
-                modelThroughputs[modelName] += instanceMetrics[0]['metrics']['throughput']
-
-        print("Total throughput: ", modelThroughputs)
-
     return True
 
 
@@ -217,8 +204,8 @@ def nShotMulti(n, modelType, prefix="nshot_multi", outDir="results"):
     linkLatest(expResultsDir)
 
     models = [
-        "resnet50",
-        "resnet50"
+        "bert",
+        "bert"
     ]
 
     prefix = f"{prefix}_{modelType}"

--- a/inference/benchmark/experiment.py
+++ b/inference/benchmark/experiment.py
@@ -205,7 +205,7 @@ def nShotMulti(n, modelType, prefix="nshot_multi", outDir="results"):
 
     models = [
         "bert",
-        "bert"
+        "resnet50"
     ]
 
     prefix = f"{prefix}_{modelType}"

--- a/inference/benchmark/rayBench.py
+++ b/inference/benchmark/rayBench.py
@@ -335,7 +335,7 @@ class runActor():
             self.stats[clientID] = profiling.profCollection()
 
         with profiling.timer('t_model_run', self.stats[clientID]):
-            results = kaas.ray.invoke(req, stats=self.stats[clientID].mod('kaas'))
+            results = kaas.ray.invoke(req, stats=self.stats[clientID].mod('kaas'), clientID=clientID)
 
         if completionQ is not None:
             completionQ.put((results, queryId))


### PR DESCRIPTION
Previously, all buffers pulled from a global key namespace. The problem is that ephemeral buffers aren't tied to the actual data layer so their keys don't really matter for the most part. Rather than requiring users to figure out global uniqueness for their ephemeral buffers, this PR uses a clientID to create a unique namespace for each client's ephemeral buffers.

A consequence of this is that replicas of the same model can no longer re-use each other's ephemeral buffers. This means there will be more cudaMalloc/Free going on which will probably hurt performance on the larger models. Honestly, this was always a questionable "accidental optimization". Looking forward, we should really write our own memory allocator that would solve most of the performance overheads.